### PR TITLE
Fix plugin loading on latest TM/OP version

### DIFF
--- a/info.toml
+++ b/info.toml
@@ -4,7 +4,4 @@ author = "bmx22c"
 category = "Streaming"
 
 siteid = 142
-version = "1.2"
-
-[script]
-imports = [ "Time.as", "Formatting.as", "Icons.as" ]
+version = "1.3"

--- a/src/Main.as
+++ b/src/Main.as
@@ -219,20 +219,6 @@ void SendInformations(string type, string content, string username, string key)
 	}
 }
 
-int GetServerPosition()
-{
-	if (g_app.CurrentPlayground is null) {
-		return 0;
-	}
-
-	auto interfaceTM = cast<CTrackManiaRaceInterface>(g_app.CurrentPlayground.Interface);
-	if (interfaceTM is null) {
-		return 0;
-	}
-
-	return interfaceTM.PlayerGeneralPosition;
-}
-
 void ResetServerInfo()
 {
 	serverLogin = '';


### PR DESCRIPTION
Fix #5 

- `GetServerPosition` was doing an invalid cast, seems like the type no longer exists. It's not called anywhere, so I assume it was just copy-pasted code that never got used, so I deleted the function.
- The config file has imports that are no longer necessary, because they got moved to being built-in according to https://openplanet.dev/docs/reference/imports

I made these changes and loaded the plugin locally, and it seems to work fine! Hopefully this looks ok to you.